### PR TITLE
Support different 'types' of garage door openers.

### DIFF
--- a/myq.py
+++ b/myq.py
@@ -21,6 +21,7 @@ CHAMBERLAIN = 'chamberlain'
 CRAFTMASTER = 'craftmaster'
 
 SUPPORTED_BRANDS = [LIFTMASTER, CHAMBERLAIN, CRAFTMASTER]
+SUPPORTED_DEVICE_TYPE_NAMES = ['GarageDoorOpener', 'Garage Door Opener WGDO']
 
 DEFAULT_BRAND = CHAMBERLAIN
 DEFAULT_NAME = "MyQ"
@@ -155,7 +156,7 @@ class MyQAPI(object):
         garage_doors = []
 
         for device in devices:
-            if device['MyQDeviceTypeName'] == 'GarageDoorOpener':
+            if device['MyQDeviceTypeName'] in SUPPORTED_DEVICE_TYPE_NAMES:
                 dev = {}
                 for attribute in device['Attributes']:
                    if attribute['AttributeDisplayName'] == 'desc':


### PR DESCRIPTION
MyQDeviceTypeName value is spelled slightly differently for newer garage door openers with
built-in Wi-Fi (Garage Door Opener WGDO). 

See, for example this mention of the same issue: https://community.home-assistant.io/t/myq-componenet-issues/1860/43

I'd love to have it done in a more generic and future-proof way, maybe based upon the attributes that the device has, if there are more than a couple of these different spellings in the wild, but I think this conservative approach (just list all possible device type names) will do for now.